### PR TITLE
comparison of Float with String failed

### DIFF
--- a/files/brews/dnsmasq.rb
+++ b/files/brews/dnsmasq.rb
@@ -25,7 +25,7 @@ class Dnsmasq < Formula
     end
 
     # Fix compilation on Lion
-    ENV.append_to_cflags "-D__APPLE_USE_RFC_3542" if 10.7 <= MACOS_VERSION
+    ENV.append_to_cflags "-D__APPLE_USE_RFC_3542" if 10.7 <= MACOS_VERSION.to_f
     inreplace "Makefile" do |s|
       s.change_make_var! "CFLAGS", ENV.cflags
     end


### PR DESCRIPTION
Somewhere in the stack trace after running `boxen`:

``` sh
Error: comparison of Float with String failed
/opt/boxen/homebrew/Library/Taps/boxen-brews/dnsmasq.rb:28:in `<='
/opt/boxen/homebrew/Library/Taps/boxen-brews/dnsmasq.rb:28:in `install'
/opt/boxen/homebrew/Library/Taps/boxen-brews/dnsmasq.rb:15
```

Upon further investigation, it appears the `MACOS_VERSION` constant was recently
changed from a `Float` to a `String`.

To prevent further issues, instead of assuming the `MACOS_VERSION` constant is
always going to be a `Float`, I suggest we actually coerce it into a `Float`
before comparison.
