### PR TITLE
Incorrect usage of ${tld}

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,7 +28,7 @@ class dnsmasq(
   }
 
   file { "/Library/LaunchDaemons/${tld}.dnsmasq.plist":
-    content => template("dnsmasq/${tld}.dnsmasq.plist.erb"),
+    content => template("dnsmasq/dev.dnsmasq.plist.erb"),
     group   => 'wheel',
     notify  => Service[$servicename],
     owner   => 'root',


### PR DESCRIPTION
Unless I am using this wrong, if you configure dnsmasq to use something other than .dev, it fails to find the template file because obviously the template file isn't going to change it's name based on the tld specified.

This change will allow it to find the template file, and because the template file appears to have placeholders in it for correctly setting the tld, and it will be named correctly, I believe this should fix the issue.
