### PR TITLE
Fix allowing different tld.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,8 +27,8 @@ class dnsmasq(
     require => File[$configdir],
   }
 
-  file { "/Library/LaunchDaemons/${tld}.dnsmasq.plist":
-    content => template("dnsmasq/${tld}.dnsmasq.plist.erb"),
+  file { '/Library/LaunchDaemons/dev.dnsmasq.plist':
+    content => template('dnsmasq/dev.dnsmasq.plist.erb'),
     group   => 'wheel',
     notify  => Service[$servicename],
     owner   => 'root',


### PR DESCRIPTION
Support for using a different tld was added in a recent version, but
when you changed it, it wouldn't use the configuration shipped with the
module. Updated to always use dev.dnsmasq for the plist config.
