### PR TITLE
Update string replacement for file path

### DIFF
--- a/files/brews/dnsmasq.rb
+++ b/files/brews/dnsmasq.rb
@@ -3,7 +3,7 @@ class Dnsmasq < Formula
   homepage "http://www.thekelleys.org.uk/dnsmasq/doc.html"
   url "http://www.thekelleys.org.uk/dnsmasq/dnsmasq-2.76.tar.gz"
   sha256 "777c4762d2fee3738a0380401f2d087b47faa41db2317c60660d69ad10a76c32"
-  version "2.76-boxen2"
+  version "2.76-boxen3"
 
   bottle do
     cellar :any_skip_relocation
@@ -26,7 +26,7 @@ class Dnsmasq < Formula
     ENV.deparallelize
 
     # Fix etc location
-    inreplace "src/config.h", "/etc/dnsmasq.conf", "#{etc}/dnsmasq.conf"
+    inreplace "src/config.h", "/etc/dnsmasq.conf", "#{etc}/boxen/dnsmasq/dnsmasq.conf"
 
     # Optional IDN support
     if build.with? "libidn"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,7 +56,7 @@ class dnsmasq(
   }
 
   package { 'boxen/brews/dnsmasq':
-    ensure => '2.76-boxen2',
+    ensure => '2.76-boxen3',
     notify => Service[$service],
   }
 

--- a/spec/classes/dnsmasq_spec.rb
+++ b/spec/classes/dnsmasq_spec.rb
@@ -55,7 +55,7 @@ describe 'dnsmasq' do
     should contain_homebrew__formula('dnsmasq')
 
     should contain_package('boxen/brews/dnsmasq').with({
-      :ensure => '2.76-boxen2',
+      :ensure => '2.76-boxen3',
       :notify => "Service[#{service_name}]",
     })
 


### PR DESCRIPTION
Now that everything will be living under the Homebrew `etc` directory,
we need to update the `inreplace` call to point to the new path.