### PR TITLE
Fix inconsistent service name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,9 +16,7 @@ class dnsmasq(
 ) {
   require homebrew
 
-  if ! $service_name {
-    $service = "${tld}.dnsmasq"
-  }
+  $service = 'dev.dnsmasq'
 
   file { [$configdir, $logdir, $datadir]:
     ensure => directory,

--- a/spec/classes/dnsmasq_spec.rb
+++ b/spec/classes/dnsmasq_spec.rb
@@ -67,7 +67,7 @@ describe 'dnsmasq' do
 
   context 'given a different tld' do
     let(:tld)         { "vagrant" }
-    let(:service_name) { "#{tld}.dnsmasq" }
+    let(:service_name) { "dev.dnsmasq" }
     let(:params) {{
       'host'       => "127.0.0.1",
       'tld'        => tld,
@@ -84,7 +84,7 @@ describe 'dnsmasq' do
         :require => "File[#{configdir}]",
       }).with_content(%r{\naddress=/vagrant/127.0.0.1\nlisten-address=127.0.0.1\n})
 
-      should contain_file('/Library/LaunchDaemons/vagrant.dnsmasq.plist').with({
+      should contain_file('/Library/LaunchDaemons/dev.dnsmasq.plist').with({
         :group   => 'wheel',
         :notify  => "Service[#{service_name}]",
         :owner   => 'root',


### PR DESCRIPTION
When the new tld option was introduced (awesome, BTW!), the name of the service became tied to the TLD used. However, ["dev" is hard-coded as a service name prefix in the boxen gem](https://github.com/boxen/boxen/blob/9c6142377ac9ed50b03e58e20ac978e83d800aed/lib/boxen/service.rb#L14).  Also, we could conceivably add more TLDs to our Dnsmasq setup, but we won't run a separate service for each one. Lastly, it might be nice to stick with the convention observed in other boxen-managed services where the service name is not tied to the configuration of the service.