### PR TITLE
Make default TLD `test`

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,3 +1,3 @@
 ---
 dnsmasq::host: 127.0.0.1
-dnsmasq::tld:  dev
+dnsmasq::tld:  test


### PR DESCRIPTION
Updates default TLD to be `test` now that `dev` is owned by Google

Fixes #16