### PR TITLE
Fix wrong service label

### DIFF
--- a/spec/classes/dnsmasq_spec.rb
+++ b/spec/classes/dnsmasq_spec.rb
@@ -88,7 +88,7 @@ describe 'dnsmasq' do
         :group   => 'wheel',
         :notify  => "Service[#{service_name}]",
         :owner   => 'root',
-      }).with_content(%r{<string>#{tld}.dnsmasq</string>})
+      }).with_content(%r{<string>dev.dnsmasq</string>})
 
       should contain_file('/etc/resolver/vagrant').with({
         :content => 'nameserver 127.0.0.1',

--- a/templates/dnsmasq.plist.erb
+++ b/templates/dnsmasq.plist.erb
@@ -3,7 +3,7 @@
 <plist version="1.0">
   <dict>
     <key>Label</key>
-    <string><%= @tld %>.dnsmasq</string>
+    <string>dev.dnsmasq</string>
 
     <key>Boxen</key>
     <dict>


### PR DESCRIPTION
Oops! I think I missed this in #24. Until this is applied, you'll still see your TLD in the label of the service (e.g. when running `launchctl list`).